### PR TITLE
get to UTF-8, otherwise insync-headless barfs on some error messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM tiredofit/debian:stretch
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
+RUN apt-get update && \
+    apt-get install -y locales locales-all
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8 
+RUN dpkg-reconfigure locales
+
 ### Install Insync
 RUN set -x && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCAF35C && \


### PR DESCRIPTION
Per subject of the commit, I needed UTF-8 to read some error messages from insync headless.

I didn't want to install locales-all, but generating the en_US.UTF-8 kept giving me errors.  If you can figure out a better way, but all means...