### PR TITLE
Some small bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM tiredofit/debian:stretch
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
+### Set locale to C.UTF-8
+ENV LANG='C.UTF-8' \
+    LANGUAGE='C.UTF-8' \
+    LC_ALL='C.UTF-8'
+
 ### Install Insync
 RUN set -x && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCAF35C && \

--- a/install/etc/cont-init.d/10-insync
+++ b/install/etc/cont-init.d/10-insync
@@ -5,7 +5,7 @@ if [ "$DEBUG_MODE" = "TRUE" ] || [ "$DEBUG_MODE" = "true" ];  then
 fi
 
 ### Set Defaults
-INSYNC1_DOWNLOAD=${DOWNLOAD:-"open-document"}
+INSYNC1_DOWNLOAD=${INSYNC1_DOWNLOAD:-"open-document"}
 PROXY_MODE=${PROXY_MODE:-"NONE"}
 
 mkdir -p /root/.config/Insync
@@ -50,7 +50,7 @@ if insync-headless get_status | grep 'UNLINKED' > dev/null; then
 
         mkdir -p /data/${!INSYNC_USERNAME}
         echo '** [insync] Adding Account '${!INSYNC_USERNAME}
-        /usr/bin/insync-headless add_account -a ${!INSYNC_AUTH_CODE} -p /data/${!INSYNC_USERNAME} -e ${!INSYNC_DOWNLOAD}          
+        echo yes | /usr/bin/insync-headless add_account -a ${!INSYNC_AUTH_CODE} -p /data/${!INSYNC_USERNAME} -e ${!INSYNC_DOWNLOAD}
     done
 fi
 /usr/bin/insync-headless set_autostart yes


### PR DESCRIPTION
71d3fe3: 
- With my Environment variable for INSYNC1_DOWNLOAD set to 'ms-office' I noticed it was actually always being set as 'open-document'.  This is happening because in 10-insync, if DOWNLOAD is not set, INSYNC1_DOWNLOAD is always set to 'open-document', but DOWNLOAD is never set because this is no longer a supported variable.
-  In the time since this Dockerfile was last built and pushed to hub.docker.io, insync-headless has started requiring the agreement be accepted (By the user typing 'yes') when adding accounts.  Piping 'yes' to the add command takes care of this.

8081a57:
- I corrected the issue reported by @jayjanssen by setting the locale environment variables to C.UTF-8 in my docker-compose.yml; the C.UTF-8 locale is included by default in all Debian installs without requiring extra locale packages be installed.  Setting these environment variables in the Dockerfile does not increase the image size (As including an extra package would) and makes it so these variables are not required to be set at container run time.