### PR TITLE
Run as Insync user instead of Root

### DIFF
--- a/install/etc/s6/services/10-insync/finish
+++ b/install/etc/s6/services/10-insync/finish
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/bin/insync-headless quit
+sudo -u insync exec /usr/bin/insync-headless quit


### PR DESCRIPTION
Unable to quit insync with root, due to the running instance being owned by insync.