### PR TITLE
Updated zabbix-agent rules to sudo to the insync user

### DIFF
--- a/install/etc/zabbix/zabbix_agentd.conf.d/insync.conf
+++ b/install/etc/zabbix/zabbix_agentd.conf.d/insync.conf
@@ -1,5 +1,5 @@
-UserParameter=insync.syncstatus,sudo insync-headless get_status
-UserParameter=insync.accounts.num,sudo insync-headless get_account_information | grep 'Quota' | wc -l
-UserParameter=insync.files.total,sudo find /data/ -type f | wc -l
+UserParameter=insync.syncstatus,sudo -u insync insync-headless get_status
+UserParameter=insync.accounts.num,sudo -u insync insync-headless get_account_information | grep 'Quota' | wc -l
+UserParameter=insync.files.total,sudo find /data/ -type f | grep -v /data/.config | wc -l
 UserParameter=insync.files.totalsize,sudo du -s /data/ | awk '{print $1'}
 


### PR DESCRIPTION
- This was broken in commit 61d8f5e as insync_headless is no longer
  running as root.